### PR TITLE
Remove launch-system private repo from ECR

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -393,15 +393,6 @@ module "private_ecr_github_actions_upload_credentials_neuroagent" {
   github_repository_name = "neuroagent"
 }
 
-module "launch_system" {
-  source = "./private-ecr-repo"
-
-  repository_name = "launch-system"
-  allowed_to_pull_identities = [
-    "arn:aws:iam::671250183987:role/launch20251028124644152500000004", # production
-  ]
-}
-
 module "launch_api" {
   source = "./private-ecr-repo"
 


### PR DESCRIPTION
Split into launch-system/api, launch-system/default-executor and launch-system/orchestrator

Also it is making the CI fail https://github.com/openbraininstitute/aws-terraform-ecr/actions/runs/21753749711/job/62758210414#step:5:427