### PR TITLE
Simplify lifecycle policy for private ECR

### DIFF
--- a/private-ecr-repo/lifecycle.tf
+++ b/private-ecr-repo/lifecycle.tf
@@ -1,36 +1,22 @@
 resource "aws_ecr_lifecycle_policy" "policy" {
-  count      = var.lifecycle_policy_max_image_count != null || var.lifecycle_policy_max_image_age_days != null ? 1 : 0
+  count      = var.lifecycle_policy_max_image_count != null ? 1 : 0
   repository = aws_ecr_repository.private_repo.name
 
   policy = <<EOF
 {
   "rules": [
-    ${var.lifecycle_policy_max_image_count != null ? jsonencode({
-  rulePriority = 1
-  description  = "Keep last ${var.lifecycle_policy_max_image_count} images"
-  selection = {
-    tagStatus   = "any"
-    countType   = "imageCountMoreThan"
-    countNumber = var.lifecycle_policy_max_image_count
-  }
-  action = {
-    type = "expire"
-  }
-  }) : ""}
-    ${var.lifecycle_policy_max_image_count != null && var.lifecycle_policy_max_image_age_days != null ? "," : ""}
-    ${var.lifecycle_policy_max_image_age_days != null ? jsonencode({
-  rulePriority = 2
-  description  = "Delete images older than ${var.lifecycle_policy_max_image_age_days} days"
-  selection = {
-    tagStatus   = "any"
-    countType   = "sinceImagePushed"
-    countUnit   = "days"
-    countNumber = var.lifecycle_policy_max_image_age_days
-  }
-  action = {
-    type = "expire"
-  }
-}) : ""}
+    {
+      "rulePriority": 1,
+      "description": "Keep last ${var.lifecycle_policy_max_image_count} images",
+      "selection": {
+        "tagStatus": "any",
+        "countType": "imageCountMoreThan",
+        "countNumber": ${var.lifecycle_policy_max_image_count}
+      },
+      "action": {
+        "type": "expire"
+      }
+    }
   ]
 }
 EOF


### PR DESCRIPTION
Seems we cannot have more than one rule applied to ANY

```
│ Error: creating ECR Lifecycle Policy (neuroagent): operation error ECR: PutLifecyclePolicy, https response error StatusCode: 400, RequestID: d57946c7-2bce-406d-b126-b735c52dff05, InvalidParameterException: Invalid parameter at 'LifecyclePolicyText' failed to satisfy constraint: 'Lifecycle policy validation failure: Only one rule can specify 'ANY' tags per storage class.'
```