### PR TITLE
Fix sandbox-nse ECR pull for the CUDA GPU executor image.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -380,7 +380,7 @@ module "launch_executor_python312_compiler_cuda128" {
   allowed_to_pull_principals = { AWS = [
     "arn:aws:iam::992382665735:role/launch_system_executor20260408081519816200000001", # staging default executor
     "arn:aws:iam::671250183987:role/launch_system_executor20260416122511009900000003", # production default executor
-    "arn:aws:iam::009203151042:role/launch_system_executor20260507100121457500000002", # sandbox-nse gpu executor
+    "arn:aws:iam::009203151042:role/launch_system_executor2026060517442080070000000b", # sandbox-nse default executor (GPU tasks use this execution role)
   ] }
   lifecycle_policy_max_image_count = 10
 }


### PR DESCRIPTION
 GPU tasks fail at startup with:

```
  CannotPullImageManifestError: User arn:aws:sts::009203151042:assumed-role/launch_system_executor2026060517442080070000000b/... is not authorized to perform ecr:BatchGetImage on
  arn:aws:ecr:us-east-1:985539765147:repository/launch-system/runtimes/python3.12-compiler-cuda12.8
```

  The CUDA repo currently allows the wrong sandbox role (…700121457500000002). GPU tasks use the default executor execution role (…7442080070000000b), same as the other launch-system
  runtime repos — update the repository policy to match.
