### PR TITLE
Fix CI warning messages

### DIFF
--- a/private-ecr-download-credentials/main.tf
+++ b/private-ecr-download-credentials/main.tf
@@ -25,7 +25,7 @@ resource "aws_iam_policy" "download_policy" {
           "ecr:BatchGetImage",
           "ecr:BatchCheckLayerAvailability",
         ]
-        Resource = ["arn:aws:ecr:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:repository/${var.ecr_repository_name}"]
+        Resource = ["arn:aws:ecr:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:repository/${var.ecr_repository_name}"]
       },
       {
         Effect = "Allow"

--- a/private-ecr-upload-credentials/credentials.tf
+++ b/private-ecr-upload-credentials/credentials.tf
@@ -67,7 +67,7 @@ resource "aws_iam_policy" "ecr_push_policy" {
           "ecr:CompleteLayerUpload",
           "ecr:DescribeRepositories"
         ]
-        Resource = ["arn:aws:ecr:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:repository/${var.ecr_repository_name}"]
+        Resource = ["arn:aws:ecr:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:repository/${var.ecr_repository_name}"]
       }
     ]
   })

--- a/production.tfvars
+++ b/production.tfvars
@@ -1,1 +1,0 @@
-terraform_remote_state_bucket_name = "obi-tfstate-ecr"


### PR DESCRIPTION
```
│ Warning: Value for undeclared variable
│ 
│ The root module does not declare a variable named
│ "terraform_remote_state_bucket_name" but a value was found in file
│ "production.tfvars". If you meant to use this value, add a "variable" block
│ to the configuration.
│ 
│ To silence these warnings, use TF_VAR_... environment variables to provide
│ certain "global" settings to all configurations in your organization. To
│ reduce the verbosity of these warnings, use the -compact-warnings option.
╵
╷
│ Warning: Deprecated value used
│ 
│   with module.private_ecr_github_actions_upload_credentials_auth_manager.aws_iam_policy.ecr_push_policy,
│   on private-ecr-upload-credentials/credentials.tf line 42, in resource "aws_iam_policy" "ecr_push_policy":
│   42:   policy = jsonencode({
│   43:     Version = "2012-10-17",
│   44:     Statement = [
│   45:       {
│   46:         Effect = "Allow"
│   47:         Action = [
│   48:           "ecr:GetAuthorizationToken"
│   49:         ]
│   50:         Resource = "*"
│   51:       },
│   52:       {
│   53:         Effect = "Allow"
│   54:         Action = [
│   55:           "sts:GetServiceBearerToken"
│   56:         ]
│   57:         Resource = "*"
│   58:       },
│   59:       {
│   60:         Effect = "Allow"
│   61:         Action = [
│   62:           "ecr:BatchCheckLayerAvailability",
│   63:           "ecr:BatchGetImage",
│   64:           "ecr:PutImage",
│   65:           "ecr:InitiateLayerUpload",
│   66:           "ecr:UploadLayerPart",
│   67:           "ecr:CompleteLayerUpload",
│   68:           "ecr:DescribeRepositories"
│   69:         ]
│   70:         Resource = ["arn:aws:ecr:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:repository/${var.ecr_repository_name}"]
│   71:       }
│   72:     ]
│   73:   })
│ 
│   The deprecation originates from module.private_ecr_github_actions_upload_credentials_auth_manager.data.aws_region.current.name
│ 
│ name is deprecated. Use region instead.
│ 
│ (and 15 more similar warnings elsewhere)
```