### PR TITLE
Bump notebook_service_private ECR lifecycle policy from 20 to 50 images

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -257,7 +257,7 @@ module "notebook_service_private" {
     "arn:aws:iam::992382665735:role/notebook_service_task_exec_ecs20250911140844036500000002", # staging
     "arn:aws:iam::671250183987:role/notebook_service_task_exec_ecs20250918112052446100000002", # production
   ] }
-  lifecycle_policy_max_image_count = 20
+  lifecycle_policy_max_image_count = 50
 }
 
 module "private_ecr_github_actions_upload_credentials_notebook_service" {


### PR DESCRIPTION
multi-arch builds push ~5 entries per tag (index + amd64 + arm64 + 2 attestation manifests), so 20 was only retaining ~4 versioned tags