### PR TITLE
Fix CodeArtifact OIDC trust policy for new GitHub immutable sub claim format

### DIFF
--- a/codeartifact/iam.tf
+++ b/codeartifact/iam.tf
@@ -100,8 +100,11 @@ resource "aws_iam_role" "github_actions_publish" {
         },
         Action = "sts:AssumeRoleWithWebIdentity",
         Condition = {
-          StringLike = {
-            "token.actions.githubusercontent.com:sub" = "repo:${var.github_organisation}/${each.value.gh_repo}:*"
+          "ForAnyValue:StringLike" = {
+            "token.actions.githubusercontent.com:sub" = [
+              "repo:${var.github_organisation}/${each.value.gh_repo}:*",
+              "repo:${var.github_organisation}@*/${each.value.gh_repo}@*:*"
+            ]
           },
           StringEquals = {
             "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"


### PR DESCRIPTION
Repos created after July 15, 2026 use repo:org@ID/repo@ID:* format. Adds both old and new patterns to the trust condition.

same thing we did in https://github.com/openbraininstitute/aws-terraform-ecr/pull/105/changes