### PR TITLE
Add ecr:GetDownloadUrlForLayer to ecr_push_policy

### DIFF
--- a/private-ecr-upload-credentials/credentials.tf
+++ b/private-ecr-upload-credentials/credentials.tf
@@ -61,6 +61,7 @@ resource "aws_iam_policy" "ecr_push_policy" {
         Action = [
           "ecr:BatchCheckLayerAvailability",
           "ecr:BatchGetImage",
+          "ecr:GetDownloadUrlForLayer",
           "ecr:PutImage",
           "ecr:InitiateLayerUpload",
           "ecr:UploadLayerPart",


### PR DESCRIPTION
Attempt to fix the error:

```
2026-08-07T14:30:58.6245078Z #10 ERROR: httpReadSeeker: failed open: unexpected status from GET request to https://985539765147.dkr.ecr.us-east-1.amazonaws.com/v2/launch-system/api/blobs/sha256:e35022bafa6a66e45721513633b67c29a0d7f641138f146b2bac368b5f07be73: 403 Forbidden
2026-08-07T14:30:58.6253816Z denied: User: arn:aws:sts::985539765147:assumed-role/gh_ecr_push_launch-system/GitHubActions is not authorized to perform: ecr:GetDownloadUrlForLayer on resource: arn:aws:ecr:us-east-1:985539765147:repository/launch-system/api because no identity-based policy allows the ecr:GetDownloadUrlForLayer action
```

from https://github.com/openbraininstitute/launch-system/actions/runs/31187213028/job/92894694167